### PR TITLE
Major UX Improvments

### DIFF
--- a/src/RemixDownloader/RemixDownloader.Core/Models/AssetOptimizationType.cs
+++ b/src/RemixDownloader/RemixDownloader.Core/Models/AssetOptimizationType.cs
@@ -1,13 +1,25 @@
-﻿namespace RemixDownloader.Core.Models
+﻿using System;
+using System.ComponentModel;
+
+namespace RemixDownloader.Core.Models
 {
+    [Flags]
     public enum AssetOptimizationType
     {
-        OriginalView,
-        OriginalDownload,
-        Preview,
-        Performance,
-        Quality,
-        HoloLens,
-        WindowsMR
+        [Description("Preview")]
+        Preview = 1,
+        [Description("Performance")]
+        Performance = 2,
+        [DefaultValue(true)]
+        [Description("Quality")]
+        Quality = 4,
+        [Description("HoloLens")]
+        HoloLens = 8,
+        [Description("Windows Mixed Reality")]
+        WindowsMR = 16,
+        [Description("Web Preview")]
+        ManifestView = 32,
+        [Description("Original Download")]
+        ManifestDownload = 64,
     }
 }

--- a/src/RemixDownloader/RemixDownloader.Core/Services/RemixApiService.cs
+++ b/src/RemixDownloader/RemixDownloader.Core/Services/RemixApiService.cs
@@ -113,35 +113,36 @@ namespace RemixDownloader.Core.Services
         ///  <param name="levelOfDetail">Level of detail requested in the downloaded model</param>
         ///  <param name="cancellationToken">Cancels operation and returns null</param>
         ///  <returns></returns>
-        public async Task<byte[]> DownloadModelFilesAsync(ModelResult model, AssetOptimizationType levelOfDetail, CancellationToken cancellationToken = new CancellationToken())
-        {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return null;
-            }
+        // TODO Determine reason why extra asset files are not downloading, then move downloading logic out of the viewmodel and back here.
+        //public async Task<byte[]> DownloadModelFilesAsync(ModelResult model, AssetOptimizationType levelOfDetail, CancellationToken cancellationToken = new CancellationToken())
+        //{
+        //    if (cancellationToken.IsCancellationRequested)
+        //    {
+        //        return null;
+        //    }
 
-            string downloadUrl = string.Empty;
+        //    string downloadUrl = string.Empty;
 
-            if (levelOfDetail == AssetOptimizationType.OriginalView)
-            {
-                downloadUrl = model.ManifestUris.FirstOrDefault(u => u.Usage == "View")?.Uri;
-            }
-            else if (levelOfDetail == AssetOptimizationType.OriginalDownload)
-            {
-                downloadUrl = model.ManifestUris.FirstOrDefault(u => u.Usage == "Download")?.Uri;
-            }
-            else
-            {
-                downloadUrl = model.AssetUris.FirstOrDefault(u => u.OptimizationType == levelOfDetail.ToString())?.Uri;
-            }
+        //    if (levelOfDetail == AssetOptimizationType.ManifestView)
+        //    {
+        //        downloadUrl = model.ManifestUris.FirstOrDefault(u => u.Usage == "View")?.Uri;
+        //    }
+        //    else if (levelOfDetail == AssetOptimizationType.ManifestDownload)
+        //    {
+        //        downloadUrl = model.ManifestUris.FirstOrDefault(u => u.Usage == "Download")?.Uri;
+        //    }
+        //    else
+        //    {
+        //        downloadUrl = model.AssetUris.FirstOrDefault(u => u.OptimizationType == levelOfDetail.ToString())?.Uri;
+        //    }
 
-            if (string.IsNullOrEmpty(downloadUrl))
-            {
-                return null;
-            }
+        //    if (string.IsNullOrEmpty(downloadUrl))
+        //    {
+        //        return null;
+        //    }
 
-            return await client.GetByteArrayAsync(downloadUrl);
-        }
+        //    return await client.GetByteArrayAsync(downloadUrl);
+        //}
 
         public void Dispose()
         {

--- a/src/RemixDownloader/RemixDownloader.Core/Utilities/EnumHelpers.cs
+++ b/src/RemixDownloader/RemixDownloader.Core/Utilities/EnumHelpers.cs
@@ -1,0 +1,42 @@
+﻿using RemixDownloader.Core.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace RemixDownloader.Core.Utilities
+{
+    public static class EnumHelpers
+    {
+        public static List<string> ReadibleAssetOptimizationTypes()
+        {
+            var list = new List<string>();
+
+            foreach (AssetOptimizationType assetType in Enum.GetValues(typeof(AssetOptimizationType)))
+            {
+                list.Add(assetType.GetDescription());
+            }
+
+            return list;
+        }
+
+        public static string GetDescription(this Enum GenericEnum)
+        {
+            Type genericEnumType = GenericEnum.GetType();
+
+            MemberInfo[] memberInfo = genericEnumType.GetMember(GenericEnum.ToString());
+
+            if (memberInfo != null && memberInfo.Length > 0)
+            {
+                var attributes = memberInfo[0].GetCustomAttributes(typeof(System.ComponentModel.DescriptionAttribute), false);
+
+                if (attributes != null && attributes.Count() > 0)
+                {
+                    return ((System.ComponentModel.DescriptionAttribute)attributes.ElementAt(0)).Description;
+                }
+            }
+            return GenericEnum.ToString();
+        }
+    }
+}

--- a/src/RemixDownloader/RemixDownloader.Uwp/App.xaml
+++ b/src/RemixDownloader/RemixDownloader.Uwp/App.xaml
@@ -12,7 +12,8 @@
 
             <converters:FileSuffixConverter x:Key="FileSuffixConverter"/>
             <converters:NullToVisibilityConverter x:Key="NullToVisibilityConverter"/>
-            <converters:ResultToBrushConverter x:Key="ResultToBrushConverter"/>
+            <converters:ResultToBrushConverter x:Key="ResultToBrushConverter" />
+            <converters:InvertBoolConverter x:Key="InvertBoolConverter" />
 
             <Style x:Key="StretchedListViewItemStyle"
                    TargetType="ListViewItem">

--- a/src/RemixDownloader/RemixDownloader.Uwp/Converters/InvertBoolConverter.cs
+++ b/src/RemixDownloader/RemixDownloader.Uwp/Converters/InvertBoolConverter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Windows.UI.Xaml.Data;
+
+namespace RemixDownloader.Uwp.Converters
+{
+    public class InvertBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if(value is bool val)
+            {
+                return !val;
+            }
+
+            return value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            if (value is bool val)
+            {
+                return !val;
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/RemixDownloader/RemixDownloader.Uwp/Converters/ResultToBrushConverter.cs
+++ b/src/RemixDownloader/RemixDownloader.Uwp/Converters/ResultToBrushConverter.cs
@@ -11,17 +11,19 @@ namespace RemixDownloader.Uwp.Converters
         {
             if (value is string status)
             {
-                if (status == "Downloading...")
+                var lowerStatus = status.ToLower();
+
+                if (lowerStatus.Contains("downloading") || lowerStatus.Contains("saving"))
                 {
                     return new SolidColorBrush(Colors.Goldenrod);
                 }
 
-                if (status == "Saved")
+                if (lowerStatus.Contains("saved"))
                 {
                     return new SolidColorBrush(Colors.MediumSeaGreen);
                 }
 
-                if (status == "Failed")
+                if (lowerStatus.Contains("failed"))
                 {
                     return new SolidColorBrush(Colors.DarkRed);
                 }

--- a/src/RemixDownloader/RemixDownloader.Uwp/MainPage.xaml
+++ b/src/RemixDownloader/RemixDownloader.Uwp/MainPage.xaml
@@ -7,8 +7,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:primitives="using:Telerik.UI.Xaml.Controls.Primitives"
       xmlns:viewModels="using:RemixDownloader.Uwp.ViewModels"
-      xmlns:data="using:Telerik.UI.Xaml.Controls.Data"
-      xmlns:listView="using:Telerik.UI.Xaml.Controls.Data.ListView"
+      xmlns:toolkit="using:Microsoft.Toolkit.Uwp.UI.Controls"
       mc:Ignorable="d"
       Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
       RequestedTheme="Light">
@@ -18,234 +17,267 @@
     </Page.DataContext>
 
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="2*" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="1*" />
         </Grid.ColumnDefinitions>
 
-        <Border Grid.Column="0"
-                BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
-                BorderThickness="0,0,0,1"
-                Background="AntiqueWhite">
-            <TextBlock Text="Available Models"
-                       HorizontalAlignment="Center"
-                       Style="{ThemeResource TitleTextBlockStyle}" />
-        </Border>
-
-        <Border Background="AntiqueWhite"
-                BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
-                BorderThickness="0,0,0,1"
-                Grid.Row="0"
-                Grid.Column="2">
-            <TextBlock Text="Selected Models"
-                       HorizontalAlignment="Center"
-                       Style="{ThemeResource TitleTextBlockStyle}" />
-        </Border>
-
-        <GridView x:Name="ModelsGridView"
-                  ItemsSource="{Binding Models}"
-                  SelectionChanged="{x:Bind ViewModel.ModelsGridView_OnSelectionChanged}"
-                  SelectionMode="Extended"
-                  IsMultiSelectCheckBoxEnabled="True"
-                  Grid.Row="1"
-                  Grid.Column="0">
-            <GridView.ItemTemplate>
-                <DataTemplate>
-                    <Grid>
-                        <Image Source="{Binding PreviewImage.Source}"
-                               Width="150"
-                               Height="150" />
-                        <StackPanel Background="#DDFFFFFF"
-                                    VerticalAlignment="Bottom"
-                                    Padding="10,5">
-                            <TextBlock Text="{Binding Name}"
-                                       FontWeight="Bold" />
-                            <TextBlock Text="{Binding FileSize, Converter={StaticResource FileSuffixConverter}}" />
-                        </StackPanel>
-                    </Grid>
-                </DataTemplate>
-            </GridView.ItemTemplate>
-        </GridView>
-
-        <ListView x:Name="SelectedModelsListView"
-                  ItemsSource="{Binding SelectedModels}"
-                  ItemContainerStyle="{StaticResource StretchedListViewItemStyle}"
-                  SelectionMode="None"
-                  Grid.Column="2"
-                  Grid.Row="1">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Grid Background="DarkSlateGray">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="150" />
-                            <ColumnDefinition />
-                        </Grid.ColumnDefinitions>
-                        <Image Source="{Binding Model.PreviewImage.Source}"
-                               Stretch="Fill"
-                               HorizontalAlignment="Stretch" />
-                        <Border Background="#DDFFFFFF"
-                                VerticalAlignment="Top"
-                                Grid.Column="1"
-                                Padding="10,5">
-                            <TextBlock Text="{Binding Model.Name}"
-                                       FontWeight="Bold" />
-                        </Border>
-
-                        <Border Background="{Binding Status, Converter={StaticResource ResultToBrushConverter}}"
-                                Visibility="{Binding Status, Converter={StaticResource NullToVisibilityConverter}}"
-                                VerticalAlignment="Bottom"
-                                Grid.Column="1"
-                                Padding="10,5">
-                            <TextBlock Text="{Binding Status}"
-                                       Foreground="White"
-                                       TextWrapping="Wrap" />
-                        </Border>
-
-                        <TextBlock Text="{Binding Model.FileSize, Converter={StaticResource FileSuffixConverter}}"
-                                   VerticalAlignment="Bottom"
-                                   HorizontalAlignment="Right"
-                                   Grid.Column="1"
-                                   Foreground="#DDFFFFFF"
-                                   Margin="5" />
-                    </Grid>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
-
-        <Grid Background="WhiteSmoke"
-              Grid.Row="2"
-              Grid.Column="0"
-              ColumnSpacing="10"
-              Padding="10">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="Auto" />
-            </Grid.ColumnDefinitions>
-
-            <StackPanel Grid.Column="0"
-                        Visibility="Collapsed">
-                <TextBlock Text="Board ID:" />
-                <TextBox x:Name="BoardIdTextBox"
-                         Text="{Binding BoardId, Mode=TwoWay}" />
-            </StackPanel>
-
-            <Button x:Name="GetBoardModelsButton"
-                    Visibility="Collapsed"
-                    Content="{Binding BoardButtonText}"
-                    Background="LightSeaGreen"
-                    Foreground="White"
-                    Click="{x:Bind ViewModel.LoadBoardModels_OnClick}"
-                    VerticalAlignment="Bottom"
-                    HorizontalAlignment="Stretch"
-                    Grid.Column="1" />
-
-            <TextBlock Text="OR"
-                       FontWeight="Bold"
-                       VerticalAlignment="Bottom"
-                       HorizontalAlignment="Center"
-                       Margin="10"
-                       Grid.Column="2"
-                       Visibility="Collapsed" />
-
-            <StackPanel VerticalAlignment="Bottom"
-                        Grid.Column="3">
-                <TextBlock Text="User ID:" />
-                <TextBox x:Name="UserIdTextBox"
-                         Text="{Binding UserId, Mode=TwoWay}" />
-            </StackPanel>
-
-            <Button x:Name="GetUserModelsButton"
-                    Content="{Binding UserButtonText}"
-                    Background="MediumSlateBlue"
-                    Foreground="White"
-                    Click="{x:Bind ViewModel.LoadUserModels_OnClick}"
-                    VerticalAlignment="Bottom"
-                    HorizontalAlignment="Stretch"
-                    Grid.Column="4"
-                    Margin="0,0,10,0" />
-
-            <Button Content="Reset"
-                    Foreground="White"
-                    Background="DarkRed"
-                    Click="{x:Bind ViewModel.Reset_OnClick}"
-                    VerticalAlignment="Bottom"
-                    HorizontalAlignment="Stretch"
-                    Grid.Column="5" />
-        </Grid>
-
-        <Grid x:Name="DownloadSettingsPanel"
-              Background="WhiteSmoke"
-              Grid.Column="2"
-              Grid.Row="2">
+        <Grid x:Name="LeftGrid">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
                 <RowDefinition />
-                <RowDefinition />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
 
-            <ComboBox x:Name="LevelOfDetailComboBox"
-                      Header="Level of Detail"
-                      ItemsSource="{Binding ModelOptimizationOptions}"
-                      SelectedItem="{Binding SelectedOptimizationOption, Mode=TwoWay}"
-                      SelectedIndex="1"
-                      VerticalAlignment="Bottom"
-                      HorizontalAlignment="Stretch"
-                      Margin="10,5,5,0"
-                      Grid.Column="0" />
+            <Border Grid.Column="0"
+                    BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
+                    BorderThickness="0,0,0,1"
+                    Background="AntiqueWhite">
+                <TextBlock Text="Available Models"
+                           HorizontalAlignment="Center"
+                           Style="{ThemeResource TitleTextBlockStyle}" />
+            </Border>
 
-            <StackPanel Grid.Column="1"
-                        Margin="5,0,10,0"
-                        VerticalAlignment="Bottom">
+            <GridView x:Name="ModelsGridView"
+                      ItemsSource="{Binding Models}"
+                      SelectionChanged="{x:Bind ViewModel.ModelsGridView_OnSelectionChanged}"
+                      SelectionMode="Extended"
+                      IsMultiSelectCheckBoxEnabled="True"
+                      Grid.Row="1"
+                      Grid.Column="0">
+                <GridView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Image Source="{Binding PreviewImage.Source}"
+                                   Width="150"
+                                   Height="150" />
+                            <StackPanel Background="#DDFFFFFF"
+                                        VerticalAlignment="Bottom"
+                                        Padding="10,5">
+                                <TextBlock Text="{Binding Name}"
+                                           FontWeight="Bold" />
+                                <TextBlock Text="{Binding FileSize, Converter={StaticResource FileSuffixConverter}}" />
+                            </StackPanel>
+                        </Grid>
+                    </DataTemplate>
+                </GridView.ItemTemplate>
+            </GridView>
 
-                <TextBlock Text="{Binding DownloadFolderName}"
-                           VerticalAlignment="Bottom"
-                           Margin="0,0,0,5" />
+            <Grid x:Name="UserIdGrid"
+                  Background="WhiteSmoke"
+                  Grid.Row="2"
+                  Grid.Column="0"
+                  ColumnSpacing="10"
+                  Padding="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
 
-                <Button x:Name="SelectTargetFolderButton"
-                        Content="Choose Folder"
+                <StackPanel Grid.Column="0"
+                            Visibility="Collapsed">
+                    <TextBlock Text="Board ID:" />
+                    <TextBox x:Name="BoardIdTextBox"
+                             Text="{Binding BoardId, Mode=TwoWay}" />
+                </StackPanel>
+
+                <Button x:Name="GetBoardModelsButton"
+                        Visibility="Collapsed"
+                        Content="{Binding BoardButtonText}"
+                        Background="LightSeaGreen"
+                        Foreground="White"
+                        Click="{x:Bind ViewModel.LoadBoardModels_OnClick}"
                         VerticalAlignment="Bottom"
                         HorizontalAlignment="Stretch"
-                        Click="{x:Bind ViewModel.SelectTargetFolderButton_OnClick}" />
-            </StackPanel>
+                        Grid.Column="1" />
 
-            <Button x:Name="DownloadButton"
-                    Content="Start Download"
-                    IsEnabled="{Binding IsReadyForDownload}"
-                    Click="{x:Bind ViewModel.Download_OnClick}"
-                    Background="DarkGoldenrod"
-                    Foreground="White"
-                    Grid.ColumnSpan="2"
-                    Grid.Row="1"
-                    HorizontalAlignment="Stretch"
-                    VerticalAlignment="Bottom"
-                    Margin="10" />
+                <TextBlock Text="OR"
+                           FontWeight="Bold"
+                           VerticalAlignment="Bottom"
+                           HorizontalAlignment="Center"
+                           Margin="10"
+                           Grid.Column="2"
+                           Visibility="Collapsed" />
+
+                <StackPanel VerticalAlignment="Bottom"
+                            Grid.Column="3">
+                    <TextBlock Text="User ID:" />
+                    <TextBox x:Name="UserIdTextBox"
+                             Text="{Binding UserId, Mode=TwoWay}" />
+                </StackPanel>
+
+                <Button x:Name="GetUserModelsButton"
+                        Content="{Binding UserButtonText}"
+                        Background="MediumSlateBlue"
+                        Foreground="White"
+                        Click="{x:Bind ViewModel.LoadUserModels_OnClick}"
+                        VerticalAlignment="Bottom"
+                        HorizontalAlignment="Stretch"
+                        Grid.Column="4"
+                        Margin="0,0,10,0" />
+
+                <Button Content="Reset"
+                        Foreground="White"
+                        Background="DarkRed"
+                        Click="{x:Bind ViewModel.Reset_OnClick}"
+                        VerticalAlignment="Bottom"
+                        HorizontalAlignment="Stretch"
+                        Grid.Column="5" />
+            </Grid>
         </Grid>
 
-        <Rectangle Fill="{ThemeResource ApplicationForegroundThemeBrush}"
-                   Width="1"
-                   Grid.Column="1"
-                   Grid.Row="0"
-                   Grid.RowSpan="3" />
+        <toolkit:GridSplitter ResizeBehavior="PreviousAndNext"
+                              ResizeDirection="Columns"
+                              Background="Gray"
+                              Foreground="White"
+                              FontSize="13"
+                              Grid.Column="1">
+            <toolkit:GridSplitter.Element>
+                <Grid>
+                    <TextBlock HorizontalAlignment="Center"
+                               IsHitTestVisible="False"
+                               VerticalAlignment="Center"
+                               Text="&#xE784;"
+                               Foreground="white"
+                               FontFamily="Segoe MDL2 Assets" />
+                </Grid>
+            </toolkit:GridSplitter.Element>
+        </toolkit:GridSplitter>
 
+        <Grid x:Name="RightGrid"
+              Grid.Column="2">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Border Background="AntiqueWhite"
+                    BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
+                    BorderThickness="0,0,0,1"
+                    Grid.Row="0"
+                    Grid.Column="2">
+                <TextBlock Text="Selected Models"
+                           HorizontalAlignment="Center"
+                           Style="{ThemeResource TitleTextBlockStyle}" />
+            </Border>
+
+            <ListView x:Name="SelectedModelsListView"
+                      ItemsSource="{Binding SelectedModels}"
+                      ItemContainerStyle="{StaticResource StretchedListViewItemStyle}"
+                      SelectionMode="None"
+                      Grid.Column="1"
+                      Grid.Row="1">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Background="DarkSlateGray">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="150" />
+                                <ColumnDefinition />
+                            </Grid.ColumnDefinitions>
+                            <Image Source="{Binding Model.PreviewImage.Source}"
+                                   Stretch="Fill"
+                                   HorizontalAlignment="Stretch" />
+                            <Border Background="#DDFFFFFF"
+                                    VerticalAlignment="Top"
+                                    Grid.Column="1"
+                                    Padding="10,5">
+                                <TextBlock Text="{Binding Model.Name}"
+                                           FontWeight="Bold" />
+                            </Border>
+
+                            <Border Background="{Binding Status, Converter={StaticResource ResultToBrushConverter}}"
+                                    Visibility="{Binding Status, Converter={StaticResource NullToVisibilityConverter}}"
+                                    VerticalAlignment="Bottom"
+                                    Grid.Column="1"
+                                    Padding="10,5">
+                                <TextBlock Text="{Binding Status}"
+                                           Foreground="White"
+                                           TextWrapping="Wrap" />
+                            </Border>
+
+                            <TextBlock Text="{Binding Model.FileSize, Converter={StaticResource FileSuffixConverter}}"
+                                       VerticalAlignment="Bottom"
+                                       HorizontalAlignment="Right"
+                                       Grid.Column="1"
+                                       Foreground="#DDFFFFFF"
+                                       Margin="5" />
+                        </Grid>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+
+            <Grid x:Name="DownloadSettingsPanel"
+                  Background="WhiteSmoke"
+                  Grid.Column="1"
+                  Grid.Row="2">
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+
+                <ComboBox x:Name="LevelOfDetailComboBox"
+                          Header="Level of Detail"
+                          ItemsSource="{Binding ModelOptimizationOptions}"
+                          SelectedItem="{Binding SelectedOptimizationOption, Mode=TwoWay}"
+                          SelectedIndex="1"
+                          VerticalAlignment="Bottom"
+                          HorizontalAlignment="Stretch"
+                          Margin="10,5,5,0"
+                          Grid.Column="0" />
+
+                <!--<Button Content="Choose Level of Detail">
+                    <Button.Flyout>
+                        <Flyout>
+                            
+                        </Flyout>
+                    </Button.Flyout>
+                </Button>-->
+
+                <StackPanel Grid.Column="1"
+                            Margin="5,0,10,0"
+                            VerticalAlignment="Bottom">
+
+                    <TextBlock Text="{Binding DownloadFolderName}"
+                               VerticalAlignment="Bottom"
+                               Margin="0,0,0,5" />
+
+                    <Button x:Name="SelectTargetFolderButton"
+                            Content="Choose Folder"
+                            VerticalAlignment="Bottom"
+                            HorizontalAlignment="Stretch"
+                            Click="{x:Bind ViewModel.SelectTargetFolderButton_OnClick}" />
+                </StackPanel>
+
+                <Button x:Name="DownloadButton"
+                        Content="Start Download"
+                        IsEnabled="{Binding IsReadyForDownload}"
+                        Click="{x:Bind ViewModel.Download_OnClick}"
+                        Background="DarkGoldenrod"
+                        Foreground="White"
+                        Grid.ColumnSpan="2"
+                        Grid.Row="1"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Bottom"
+                        Margin="10" />
+            </Grid>
+        </Grid>
+        
         <Grid x:Name="BusyOverlayGrid"
               Visibility="{Binding IsBusy}"
               Grid.Row="1"
               Grid.RowSpan="2"
               Grid.Column="0"
-              Grid.ColumnSpan="3"
+              Grid.ColumnSpan="2"
               Background="#AAFFFFFF">
             <StackPanel HorizontalAlignment="Center"
                         VerticalAlignment="Center"

--- a/src/RemixDownloader/RemixDownloader.Uwp/MainPage.xaml
+++ b/src/RemixDownloader/RemixDownloader.Uwp/MainPage.xaml
@@ -31,11 +31,10 @@
             </Grid.RowDefinitions>
 
             <Border Grid.Column="0"
-                    BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
-                    BorderThickness="0,0,0,1"
-                    Background="AntiqueWhite">
+                    Background="{ThemeResource AppBarBackgroundThemeBrush}">
                 <TextBlock Text="Available Models"
                            HorizontalAlignment="Center"
+                           Foreground="{ThemeResource AppBarItemForegroundThemeBrush}"
                            Style="{ThemeResource TitleTextBlockStyle}" />
             </Border>
 
@@ -157,13 +156,12 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
 
-            <Border Background="AntiqueWhite"
-                    BorderBrush="{ThemeResource ApplicationForegroundThemeBrush}"
-                    BorderThickness="0,0,0,1"
+            <Border Background="{ThemeResource AppBarBackgroundThemeBrush}"
                     Grid.Row="0"
                     Grid.Column="2">
                 <TextBlock Text="Selected Models"
                            HorizontalAlignment="Center"
+                           Foreground="{ThemeResource AppBarItemForegroundThemeBrush}"
                            Style="{ThemeResource TitleTextBlockStyle}" />
             </Border>
 
@@ -175,7 +173,7 @@
                       Grid.Row="1">
                 <ListView.ItemTemplate>
                     <DataTemplate>
-                        <Grid Background="DarkSlateGray">
+                        <Grid Background="{ThemeResource SystemControlAccentAcrylicElementAccentMediumHighBrush}">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="150" />
                                 <ColumnDefinition />
@@ -214,9 +212,11 @@
 
             <Grid x:Name="DownloadSettingsPanel"
                   Background="WhiteSmoke"
+                  Padding="10"
                   Grid.Column="1"
                   Grid.Row="2">
                 <Grid.RowDefinitions>
+                    <RowDefinition />
                     <RowDefinition />
                     <RowDefinition />
                 </Grid.RowDefinitions>
@@ -225,38 +225,82 @@
                     <ColumnDefinition />
                 </Grid.ColumnDefinitions>
 
-                <ComboBox x:Name="LevelOfDetailComboBox"
-                          Header="Level of Detail"
-                          ItemsSource="{Binding ModelOptimizationOptions}"
-                          SelectedItem="{Binding SelectedOptimizationOption, Mode=TwoWay}"
-                          SelectedIndex="1"
-                          VerticalAlignment="Bottom"
-                          HorizontalAlignment="Stretch"
-                          Margin="10,5,5,0"
-                          Grid.Column="0" />
+                <TextBlock Text="Add optimized versions:"
+                           VerticalAlignment="Bottom"
+                           Grid.Column="0" />
 
-                <!--<Button Content="Choose Level of Detail">
+                <Button Content="Choose Extras"
+                        IsEnabled="{Binding IsBusy, Converter={StaticResource InvertBoolConverter}}"
+                        VerticalAlignment="Bottom"
+                        HorizontalAlignment="Stretch"
+                        Margin="0,5,5,0"
+                        Grid.Column="0"
+                        Grid.Row="1">
                     <Button.Flyout>
-                        <Flyout>
-                            
+                        <Flyout LightDismissOverlayMode="On">
+                            <StackPanel Width="400"
+                                        Padding="10"
+                                        Spacing="10"
+                                        VerticalAlignment="Center"
+                                        Grid.Row="1"
+                                        Background="{ThemeResource SystemControlAcrylicElementBrush}">
+                                <StackPanel.Resources>
+                                    <Style TargetType="CheckBox">
+                                        <Setter Property="Margin"
+                                                Value="5,0" />
+                                        <Setter Property="IsChecked"
+                                                Value="False" />
+                                        <Setter Property="IsThreeState"
+                                                Value="False" />
+                                    </Style>
+                                </StackPanel.Resources>
+                                <TextBlock Text="Optimized Level of Detail"
+                                           Style="{ThemeResource TitleTextBlockStyle}"
+                                           HorizontalAlignment="Center" />
+                                <TextBlock Text="In addition to the original model file, optimized verisons are also available. All selections will be saved in addition to the original."
+                                           HorizontalAlignment="Center"
+                                           TextWrapping="Wrap"
+                                           Margin="0,0,0,10" />
+                                <TextBlock Text="Select downloads"
+                                           Foreground="{ThemeResource SystemAccentColor}" />
+                                <CheckBox Tag="Preview"
+                                          Content="Preview"
+                                          Checked="{x:Bind ViewModel.OptimizationCheckBox_Checked}"
+                                          Unchecked="{x:Bind ViewModel.OptimizationCheckBox_Unchecked}" />
+                                <CheckBox Tag="Performance"
+                                          Content="Performance"
+                                          Checked="{x:Bind ViewModel.OptimizationCheckBox_Checked}"
+                                          Unchecked="{x:Bind ViewModel.OptimizationCheckBox_Unchecked}" />
+                                <CheckBox Tag="Quality"
+                                          Content="Quality"
+                                          Checked="{x:Bind ViewModel.OptimizationCheckBox_Checked}"
+                                          Unchecked="{x:Bind ViewModel.OptimizationCheckBox_Unchecked}" />
+                                <CheckBox Tag="HoloLens"
+                                          Content="HoloLens (converted to glb)"
+                                          Checked="{x:Bind ViewModel.OptimizationCheckBox_Checked}"
+                                          Unchecked="{x:Bind ViewModel.OptimizationCheckBox_Unchecked}" />
+                                <CheckBox Tag="WindowsMR"
+                                          Content="Windows Mixed Reality (converted to glb)"
+                                          Checked="{x:Bind ViewModel.OptimizationCheckBox_Checked}"
+                                          Unchecked="{x:Bind ViewModel.OptimizationCheckBox_Unchecked}" />
+                            </StackPanel>
                         </Flyout>
                     </Button.Flyout>
-                </Button>-->
+                </Button>
 
-                <StackPanel Grid.Column="1"
-                            Margin="5,0,10,0"
-                            VerticalAlignment="Bottom">
+                <TextBlock Text="{Binding DownloadFolderName}"
+                           VerticalAlignment="Bottom"
+                           Margin="0,0,0,0"
+                           Grid.Column="1" />
 
-                    <TextBlock Text="{Binding DownloadFolderName}"
-                               VerticalAlignment="Bottom"
-                               Margin="0,0,0,5" />
-
-                    <Button x:Name="SelectTargetFolderButton"
-                            Content="Choose Folder"
-                            VerticalAlignment="Bottom"
-                            HorizontalAlignment="Stretch"
-                            Click="{x:Bind ViewModel.SelectTargetFolderButton_OnClick}" />
-                </StackPanel>
+                <Button x:Name="SelectTargetFolderButton"
+                        IsEnabled="{Binding IsBusy, Converter={StaticResource InvertBoolConverter}}"
+                        Content="Choose Folder"
+                        VerticalAlignment="Bottom"
+                        HorizontalAlignment="Stretch"
+                        Click="{x:Bind ViewModel.SelectTargetFolderButton_OnClick}"
+                        Grid.Column="1"
+                        Grid.Row="1" />
 
                 <Button x:Name="DownloadButton"
                         Content="Start Download"
@@ -265,36 +309,36 @@
                         Background="DarkGoldenrod"
                         Foreground="White"
                         Grid.ColumnSpan="2"
-                        Grid.Row="1"
+                        Grid.Row="2"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Bottom"
-                        Margin="10" />
+                        Margin="0,10,0,0" />
             </Grid>
         </Grid>
-        
-        <Grid x:Name="BusyOverlayGrid"
-              Visibility="{Binding IsBusy}"
-              Grid.Row="1"
-              Grid.RowSpan="2"
-              Grid.Column="0"
-              Grid.ColumnSpan="2"
-              Background="#AAFFFFFF">
-            <StackPanel HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Spacing="20">
-                <primitives:RadBusyIndicator x:Name="BusyIndicator"
-                                             Width="100"
-                                             Height="100"
-                                             Content="{Binding IsBusyMessage}"
-                                             IsActive="{Binding IsBusy}"
-                                             AnimationStyle="AnimationStyle5" />
-                <Button x:Name="CancelDownloadButton"
-                        Content="Cancel"
-                        Background="DarkRed"
-                        Foreground="White"
-                        HorizontalAlignment="Stretch"
-                        Click="{x:Bind ViewModel.Cancel_OnClick}" />
-            </StackPanel>
-        </Grid>
+
+        <primitives:RadBusyIndicator x:Name="BusyIndicator"
+                                     IsActive="{Binding IsBusy}"
+                                     AnimationStyle="AnimationStyle5"
+                                     Grid.Row="1"
+                                     Grid.RowSpan="2"
+                                     Grid.Column="0"
+                                     Grid.ColumnSpan="3"
+                                     Background="#AAFFFFFF"
+                                     VerticalAlignment="Stretch"
+                                     HorizontalAlignment="Stretch"
+                                     HorizontalContentAlignment="Center"
+                                     VerticalContentAlignment="Center">
+            <primitives:RadBusyIndicator.Content>
+                <StackPanel HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Spacing="20">
+                    <TextBlock Text="{Binding IsBusyMessage}" />
+                    <Button x:Name="CancelDownloadButton"
+                            Content="Cancel"
+                            HorizontalAlignment="Center"
+                            Click="{x:Bind ViewModel.Cancel_OnClick}" />
+                </StackPanel>
+            </primitives:RadBusyIndicator.Content>
+        </primitives:RadBusyIndicator>
     </Grid>
 </Page>

--- a/src/RemixDownloader/RemixDownloader.Uwp/Package.appxmanifest
+++ b/src/RemixDownloader/RemixDownloader.Uwp/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="adcc87fa-b966-47bb-97c3-75a6e8972f14"
     Publisher="CN=lance"
-    Version="1.0.0.0" />
+    Version="2019.720.1.0" />
 
   <mp:PhoneIdentity PhoneProductId="adcc87fa-b966-47bb-97c3-75a6e8972f14" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/RemixDownloader/RemixDownloader.Uwp/RemixDownloader.Uwp.csproj
+++ b/src/RemixDownloader/RemixDownloader.Uwp/RemixDownloader.Uwp.csproj
@@ -166,6 +166,9 @@
     <PackageReference Include="Microsoft.Toolkit.Uwp.UI">
       <Version>5.1.1</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls">
+      <Version>5.1.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.1.190606001</Version>
     </PackageReference>

--- a/src/RemixDownloader/RemixDownloader.Uwp/RemixDownloader.Uwp.csproj
+++ b/src/RemixDownloader/RemixDownloader.Uwp/RemixDownloader.Uwp.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Common\IScrollToItem.cs" />
     <Compile Include="Converters\FileSuffixConverter.cs" />
     <Compile Include="Common\SampleDataHelpers.cs" />
+    <Compile Include="Converters\InvertBoolConverter.cs" />
     <Compile Include="Converters\NullToVisibilityConverter.cs" />
     <Compile Include="Converters\ResultToBrushConverter.cs" />
     <Compile Include="MainPage.xaml.cs">

--- a/src/RemixDownloader/RemixDownloader.Uwp/ViewModels/MainViewModel.cs
+++ b/src/RemixDownloader/RemixDownloader.Uwp/ViewModels/MainViewModel.cs
@@ -318,7 +318,7 @@ namespace RemixDownloader.Uwp.ViewModels
 
                     string fileType = string.Empty;
 
-                    if (levelOfDetail == AssetOptimizationType.OriginalView || levelOfDetail == AssetOptimizationType.OriginalDownload)
+                    if (levelOfDetail == AssetOptimizationType.OriginalView)
                     {
                         fileType = item.Model.ManifestUris.FirstOrDefault(u => u.Usage == "View")?.Format;
                     }


### PR DESCRIPTION
The user can now add extra pre-optimized model files when downloading:

![image](https://user-images.githubusercontent.com/3520532/61584300-562c8f80-ab13-11e9-9e7b-12ed786d609f.png)

this will be saved alongside the original model file that was saved:

![image](https://user-images.githubusercontent.com/3520532/61584322-bd4a4400-ab13-11e9-9887-6ca7c8e77b62.png)


This PR also contains a lot of other improvements, including a fix for when some optimized model versions would fail the download. See commit history for more details.