### PR TITLE
Download glTF resources

### DIFF
--- a/src/RemixDownloader/RemixDownloader.Core/Models/GltfBuffer.cs
+++ b/src/RemixDownloader/RemixDownloader.Core/Models/GltfBuffer.cs
@@ -1,0 +1,14 @@
+
+using Newtonsoft.Json;
+
+namespace RemixDownloader.Core.Models
+{
+    public class GltfBuffer
+    {
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        [JsonProperty("byteLength")]
+        public int ByteLength { get; set; }
+    }
+}

--- a/src/RemixDownloader/RemixDownloader.Core/Models/GltfFile.cs
+++ b/src/RemixDownloader/RemixDownloader.Core/Models/GltfFile.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace RemixDownloader.Core.Models
+{
+    public class GltfFile
+    {
+        [JsonProperty("buffers")]
+        public List<GltfBuffer> Buffers { get; set; }
+
+        [JsonProperty("images")]
+        public List<GltfImage> Images { get; set; }
+
+        public static GltfFile FromJson(string json) => JsonConvert.DeserializeObject<GltfFile>(json, new JsonSerializerSettings
+        {
+            MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+            DateParseHandling = DateParseHandling.None,
+            Converters =
+            {
+                new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
+            },
+        });
+    }
+}

--- a/src/RemixDownloader/RemixDownloader.Core/Models/GltfImage.cs
+++ b/src/RemixDownloader/RemixDownloader.Core/Models/GltfImage.cs
@@ -1,0 +1,14 @@
+
+using Newtonsoft.Json;
+
+namespace RemixDownloader.Core.Models
+{
+    public class GltfImage
+    {
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        [JsonProperty("mimeType")]
+        public string MimeType { get; set; }
+    }
+}


### PR DESCRIPTION
When using the console downloader, the referenced 'Download' glTF file would be downloaded, but the binary data and images would be left out. To resolve this issue, the console application now inspects the downloaded glTF for referenced resources, and attempts to download them. Additionally, this should resolve an issue that prevented downloaded models from any user with fewer than 10 models. It should also report the number of downloaded models more accurately. It should also resolve an issue where multiple models with the same name would get overwritten.

Please let me know if there are nits or suggestions, I'm happy to update this PR :)